### PR TITLE
Remove nested await when possible

### DIFF
--- a/src/neon_signer.rs
+++ b/src/neon_signer.rs
@@ -208,10 +208,10 @@ impl NeonCallbackSigner {
 
         rt.spawn(async move {
             let signer = NeonCallbackSigner::new(channel.clone(), callback, config);
-            let result = match <Self as AsyncSigner>::sign(&signer, data).await {
-                Ok(sig) => Ok(sig),
-                Err(e) => Err(e.to_string()),
-            };
+            let result = <Self as AsyncSigner>::sign(&signer, data)
+                .await
+                .map_err(|e| e.to_string());
+
             deferred.settle_with(&channel, move |mut cx| match result {
                 Ok(signature) => {
                     let buffer = JsBuffer::from_slice(&mut cx, &signature)?;


### PR DESCRIPTION
## Overview

**Summary:**

This removes some of the nested await blocks, replacing them with plain(-er) error management.

## Technical notes

Alternatives:

- plain matches (simpler, verbose)
- closures (less idiomatic)
