### PR TITLE
Cure for jest open handles

### DIFF
--- a/js-src/Builder.spec.ts
+++ b/js-src/Builder.spec.ts
@@ -196,6 +196,7 @@ describe("Builder", () => {
 
     it("should sign data", async () => {
       const dest = { path: path.join(tempDir, "signed.jpg") };
+      await Promise.resolve();
       const signer = LocalSigner.newSigner(publicKey, privateKey, "es256");
 
       const bytes = builder.sign(signer, source, dest);

--- a/js-src/Reader.spec.ts
+++ b/js-src/Reader.spec.ts
@@ -158,6 +158,7 @@ describe("Reader", () => {
   });
 
   it("should read from a file", async () => {
+    await Promise.resolve();
     const reader = await Reader.fromAsset({
       path: "./tests/fixtures/CAI.jpg",
     });
@@ -194,6 +195,7 @@ describe("Reader", () => {
   it("should write to a file", async () => {
     let bytesWritten = 0;
     const outputPath = path.join(tempDir, "thumbnail.jpg");
+    await Promise.resolve();
     const reader = await Reader.fromAsset({
       path: "./tests/fixtures/CAI.jpg",
     });
@@ -210,6 +212,7 @@ describe("Reader", () => {
   });
 
   it("should report manifest is embedded", async () => {
+    await Promise.resolve();
     const reader = await Reader.fromAsset({
       path: "./tests/fixtures/CAI.jpg",
     });
@@ -218,6 +221,7 @@ describe("Reader", () => {
   });
 
   it("should report manifest is not embedded", async () => {
+    await Promise.resolve();
     const reader = await Reader.fromAsset({
       path: "./tests/fixtures/cloud.jpg",
     });

--- a/js-src/Trustmark.spec.ts
+++ b/js-src/Trustmark.spec.ts
@@ -97,6 +97,7 @@ describe("Trustmark", () => {
   describe("encode", () => {
     it("should encode a watermark into an image with default watermark", async () => {
       const strength = 0.9;
+      await Promise.resolve();
       const encodedImage = await trustmark.encode(testImage, strength);
 
       expect(encodedImage).toBeDefined();
@@ -109,6 +110,7 @@ describe("Trustmark", () => {
     it("should encode a watermark into an image with custom watermark", async () => {
       const strength = 0.95;
       const customWatermark = "0101000011001";
+      await Promise.resolve();
       const encodedImage = await trustmark.encode(
         testImage,
         strength,
@@ -131,6 +133,7 @@ describe("Trustmark", () => {
 
     it("should throw error with empty image buffer", async () => {
       const emptyBuffer = Buffer.alloc(0);
+      await Promise.resolve();
       await expect(trustmark.encode(emptyBuffer, 0.5)).rejects.toThrow(
         "The image format could not be determined",
       );
@@ -143,6 +146,7 @@ describe("Trustmark", () => {
       const customWatermark = "0101000011001";
 
       // First encode a watermark
+      await Promise.resolve();
       const rawPixelData = await trustmark.encode(
         testImage,
         strength,
@@ -170,6 +174,7 @@ describe("Trustmark", () => {
       const strength = 0.75;
 
       // Encode with default watermark
+      await Promise.resolve();
       const rawPixelData = await trustmark.encode(testImage, strength);
 
       // Convert raw pixel data to JPEG format for decoding
@@ -189,6 +194,7 @@ describe("Trustmark", () => {
 
     it("should throw error decoding from original image (no watermark)", async () => {
       // Try to decode from an image that hasn't been watermarked
+      await Promise.resolve();
       await expect(trustmark.decode(testImage)).rejects.toThrow(
         "watermark is corrupt or missing",
       );
@@ -196,6 +202,7 @@ describe("Trustmark", () => {
 
     it("should throw error with empty image buffer", async () => {
       const emptyBuffer = Buffer.alloc(0);
+      await Promise.resolve();
       await expect(trustmark.decode(emptyBuffer)).rejects.toThrow(
         "The image format could not be determined",
       );


### PR DESCRIPTION
Empty `await` ensures a clean js loop before calling tested function.

I suspect open handles are due to some jest shenanigans.

Changes are devex only.