### PR TITLE
Added a way to use custom rust binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,3 +637,13 @@ const builder = Builder.new(urlSettings);
 - `generate_c2pa_archive` - Whether to generate C2PA archive format
 
 **Note:** Settings are passed as per-instance configuration. There are no global settings that affect all Readers and Builders.
+
+### Build and use custom binary
+**Build rust binary:**
+```
+npm run build:rust
+```
+**Use custom rust binary:**
+```bash
+export C2PA_LIBRARY_PATH=<path-to-binary-folder>/index.node
+```

--- a/js-src/binary.ts
+++ b/js-src/binary.ts
@@ -23,7 +23,8 @@ let neon: any = null;
 // Get the binary module (loads synchronously on first access)
 export function getNeonBinary() {
   if (neon === null) {
-    neon = require("./index.node");
+    const C2PA_LIBRARY_PATH = process.env.C2PA_LIBRARY_PATH;
+    neon = require(C2PA_LIBRARY_PATH ?? "./index.node");
   }
   return neon;
 }


### PR DESCRIPTION
**Problem:** 
The binaries are built on a particular OS version might not be compatible with other OS versions, due to glib or ABI incompatibilities.

**Solution:** Add a environment variable `C2PA_LIBRARY_PATH` to supply a custom built rust binary.