### PR TITLE
Expose Builder.signDataHashedEmbeddable

### DIFF
--- a/.changeset/embeddable-data-hash.md
+++ b/.changeset/embeddable-data-hash.md
@@ -1,0 +1,5 @@
+---
+"@contentauth/c2pa-node": minor
+---
+
+Expose `Builder.signDataHashedEmbeddable` and `Builder.signDataHashedEmbeddableAsync`. The Builder produces a signed embeddable manifest from a pre-computed `DataHash` (e.g. raw `SHA-256` of the asset) without requiring the asset bytes at sign time. Useful for sidecar `.c2pa` files and remote-manifest workflows.

--- a/.changeset/embeddable-data-hash.md
+++ b/.changeset/embeddable-data-hash.md
@@ -1,5 +1,0 @@
----
-"@contentauth/c2pa-node": minor
----
-
-Expose `Builder.signDataHashedEmbeddable` and `Builder.signDataHashedEmbeddableAsync`. The Builder produces a signed embeddable manifest from a pre-computed `DataHash` (e.g. raw `SHA-256` of the asset) without requiring the asset bytes at sign time. Useful for sidecar `.c2pa` files and remote-manifest workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @contentauth/c2pa-node
+# @stabilityprotocol/c2pa-node
 
 ## 0.5.5
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,54 @@ const definition = restoredBuilder.getManifestDefinition();
 console.log(definition.ingredients); // Contains the ingredient
 ```
 
+#### Signing a data-hashed embeddable manifest
+
+When the asset bytes are not available at sign time but you already know the
+asset's hash, use `signDataHashedEmbeddable` (sync) or
+`signDataHashedEmbeddableAsync` (async, callback signer). The Builder produces
+a signed embeddable manifest binary from the supplied `DataHash`, with no
+asset I/O. The caller embeds the result, ships it as a `.c2pa` sidecar, or
+hosts it for remote-manifest fetch.
+
+With `exclusions: []` and `alg: "sha256"`, the resulting `c2pa.hash.data.hash`
+equals `SHA-256(asset)` — a verifier with the original file recomputes the
+same digest and the manifest validates.
+
+```javascript
+import * as crypto from 'node:crypto';
+import { Builder, LocalSigner } from '@contentauth/c2pa-node';
+
+const signer = LocalSigner.newSigner(cert, key, 'es256');
+
+const builder = Builder.withJson(manifestDefinition);
+
+// Pre-computed SHA-256 of the asset (e.g. taken from a manifest, DB row, etc.)
+const hash = crypto.createHash('sha256').update(assetBytes).digest();
+
+const manifestBytes = builder.signDataHashedEmbeddable(
+  signer,
+  { name: 'raw asset', alg: 'sha256', hash, exclusions: [] },
+  'image/jpeg',
+);
+
+// `manifestBytes` is preformatted for the target format (e.g. JPEG APP11
+// segment, MP4 uuid box). Embed it, write a sidecar, or serve as a remote
+// manifest.
+await fs.writeFile('asset.jpg.c2pa', manifestBytes);
+```
+
+The async variant takes a `CallbackSigner` (e.g. KMS-backed):
+
+```javascript
+const manifestBytes = await builder.signDataHashedEmbeddableAsync(
+  callbackSigner,
+  { alg: 'sha256', hash, exclusions: [] },
+  'image/jpeg',
+);
+```
+
+`DataHash` mirrors the c2pa-rs `DataHash` serde struct: `{ name?, alg?, hash, pad?, exclusions? }`. `hash` and `pad` accept `Buffer`, `Uint8Array`, or `number[]`. `exclusions` is `{ start, length }[]`; pass `[]` for whole-asset hashing.
+
 For complete type definitions, see the [@contentauth/c2pa-types](https://www.npmjs.com/package/@contentauth/c2pa-types) package.
 
 ### Signers

--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ If you need to manage multiple versions of Node on your machine, use a tool such
 Using npm:
 
 ```sh
-$ npm install @contentauth/c2pa-node
+$ npm install @stabilityprotocol/c2pa-node
 ```
 
 Using Yarn:
 
 ```sh
-$ yarn add @contentauth/c2pa-node
+$ yarn add @stabilityprotocol/c2pa-node
 ```
 
 Using pnpm:
 
 ```sh
-$ pnpm add @contentauth/c2pa-node
+$ pnpm add @stabilityprotocol/c2pa-node
 ```
 
 This command will download precompiled binaries for the following systems:
@@ -47,7 +47,7 @@ This command will download precompiled binaries for the following systems:
 
 ## Documentation
 
-Complete API documentation is generated from TypeScript source using [TypeDoc](https://typedoc.org/) and published to GitHub Pages at [https://contentauth.github.io/c2pa-node-v2/](https://contentauth.github.io/c2pa-node-v2/).
+Complete API documentation is generated from TypeScript source using [TypeDoc](https://typedoc.org/) and published to GitHub Pages at [https://stabilityprotocol.github.io/c2pa-node-v2/](https://stabilityprotocol.github.io/c2pa-node-v2/).
 
 To generate documentation locally:
 
@@ -64,7 +64,7 @@ This generates HTML documentation in the `docs/` directory. The `docs/` director
 The `Reader` class is used to read and validate C2PA manifests from media files. It can parse embedded manifests or fetch remote manifests. Refer to the [Rust SDK](https://github.com/contentauth/c2pa-rs) for the list of settings and their effects.
 
 ```javascript
-import { Reader } from '@contentauth/c2pa-node';
+import { Reader } from '@stabilityprotocol/c2pa-node';
 
 // Read from an asset file
 const reader = await Reader.fromAsset(inputAsset);
@@ -99,7 +99,7 @@ const remoteUrl = reader.remoteUrl();
 The `Builder` class is the main component for creating and signing C2PA manifests. It provides methods to add assertions, resources, and ingredients to manifests, and handles the signing process. Use the `Signer` class to sign the manifests. Refer to the [Rust SDK](https://github.com/contentauth/c2pa-rs) for the list of settings and their effects.
 
 ```javascript
-import { Builder } from '@contentauth/c2pa-node';
+import { Builder } from '@stabilityprotocol/c2pa-node';
 
 // Create a new builder
 const builder = Builder.new();
@@ -265,7 +265,7 @@ There are two types of archives sharing the same binary format:
 ##### Reading an archive and adding its ingredients
 
 ```javascript
-import { Reader, Builder } from '@contentauth/c2pa-node';
+import { Reader, Builder } from '@stabilityprotocol/c2pa-node';
 import * as fs from 'node:fs/promises';
 
 // Read the archive using the application/c2pa MIME type
@@ -419,7 +419,7 @@ same digest and the manifest validates.
 
 ```javascript
 import * as crypto from 'node:crypto';
-import { Builder, LocalSigner } from '@contentauth/c2pa-node';
+import { Builder, LocalSigner } from '@stabilityprotocol/c2pa-node';
 
 const signer = LocalSigner.newSigner(cert, key, 'es256');
 
@@ -463,7 +463,7 @@ The library provides several types of signers for different use cases:
 For local signing with certificates and private keys:
 
 ```javascript
-import { LocalSigner } from '@contentauth/c2pa-node';
+import { LocalSigner } from '@stabilityprotocol/c2pa-node';
 
 // Create a local signer with certificate and private key
 const signer = LocalSigner.newSigner(
@@ -482,7 +482,7 @@ const signature = signer.sign(dataBuffer);
 For custom signing implementations using callbacks:
 
 ```javascript
-import { CallbackSigner } from '@contentauth/c2pa-node';
+import { CallbackSigner } from '@stabilityprotocol/c2pa-node';
 
 // Create a callback signer
 const signer = CallbackSigner.newSigner(
@@ -508,7 +508,7 @@ For working with identity assertions and CAWG (Content Authenticity Working Grou
 Builds identity assertions with roles and referenced assertions:
 
 ```javascript
-import { IdentityAssertionBuilder, CallbackCredentialHolder } from '@contentauth/c2pa-node';
+import { IdentityAssertionBuilder, CallbackCredentialHolder } from '@stabilityprotocol/c2pa-node';
 
 // Create a credential holder
 const credentialHolder = CallbackCredentialHolder.newCallbackCredentialHolder(
@@ -535,7 +535,7 @@ identityBuilder.addReferencedAssertions(['c2pa.actions']);
 Signs manifests with identity assertions:
 
 ```javascript
-import { IdentityAssertionSigner } from '@contentauth/c2pa-node';
+import { IdentityAssertionSigner } from '@stabilityprotocol/c2pa-node';
 
 // Create an identity assertion signer
 const identitySigner = IdentityAssertionSigner.new(callbackSigner);
@@ -552,7 +552,7 @@ const manifest = await builder.signAsync(identitySigner, inputAsset, outputAsset
 The `Trustmark` class provides functionality for encoding and decoding trustmarks in images:
 
 ```javascript
-import { Trustmark } from '@contentauth/c2pa-node';
+import { Trustmark } from '@stabilityprotocol/c2pa-node';
 
 // Create a trustmark instance
 const trustmark = await Trustmark.newTrustmark({
@@ -579,7 +579,7 @@ The library provides comprehensive settings management that can be configured pe
 Settings can be passed directly to `Reader` and `Builder` constructors:
 
 ```javascript
-import { Reader, Builder } from '@contentauth/c2pa-node';
+import { Reader, Builder } from '@stabilityprotocol/c2pa-node';
 
 // Create settings object
 const settings = {
@@ -619,7 +619,7 @@ import {
   settingsToJson,
   loadSettingsFromFile,
   loadSettingsFromUrl
-} from '@contentauth/c2pa-node';
+} from '@stabilityprotocol/c2pa-node';
 
 // Create trust settings
 const trustSettings = createTrustSettings({

--- a/js-src/Builder.spec.ts
+++ b/js-src/Builder.spec.ts
@@ -445,6 +445,59 @@ describe("Builder", () => {
       expect(activeManifest?.title).toBe("Test_Manifest");
     });
 
+    it("should sign a pre-computed DataHash (LocalSigner, sync)", async () => {
+      const signer = LocalSigner.newSigner(publicKey, privateKey, "es256");
+
+      // Raw SHA-256 of the source asset bytes. With exclusions=[], the
+      // resulting manifest's c2pa.hash.data.hash equals this digest.
+      const hash = crypto.createHash("sha256").update(source.buffer).digest();
+
+      const manifestBytes = builder.signDataHashedEmbeddable(
+        signer,
+        {
+          name: "raw asset",
+          alg: "sha256",
+          hash,
+          exclusions: [],
+        },
+        "image/jpeg",
+      );
+
+      expect(Buffer.isBuffer(manifestBytes)).toBe(true);
+      expect(manifestBytes.length).toBeGreaterThan(0);
+      // Returned bytes are preformatted for the target format (JPEG APP11
+      // segment). The c2pa JUMBF box label "c2pa" appears inside.
+      expect(manifestBytes.toString("binary")).toContain("c2pa");
+    });
+
+    it("should sign a pre-computed DataHash (CallbackSigner, async)", async () => {
+      const signerConfig: JsCallbackSignerConfig = {
+        alg: "es256",
+        certs: [publicKey],
+        reserveSize: 10000,
+        tsaUrl: undefined,
+        directCoseHandling: false,
+      };
+      const testSigner = new TestSigner(privateKey);
+      const signer = CallbackSigner.newSigner(signerConfig, testSigner.sign);
+
+      const hash = crypto.createHash("sha256").update(source.buffer).digest();
+
+      const manifestBytes = await builder.signDataHashedEmbeddableAsync(
+        signer,
+        {
+          alg: "sha256",
+          hash,
+          exclusions: [],
+        },
+        "image/jpeg",
+      );
+
+      expect(Buffer.isBuffer(manifestBytes)).toBe(true);
+      expect(manifestBytes.length).toBeGreaterThan(0);
+      expect(manifestBytes.toString("binary")).toContain("c2pa");
+    });
+
     it("should preserve JSON assertion characters without escaping", async () => {
       const fingerprintAssertion = JSON.stringify({
         alg: "sha256",

--- a/js-src/Builder.ts
+++ b/js-src/Builder.ts
@@ -24,6 +24,7 @@ import type {
   C2paSettings,
   CallbackSignerInterface,
   ClaimVersion,
+  DataHash,
   DestinationAsset,
   FileAsset,
   IdentityAssertionSignerInterface,
@@ -35,6 +36,29 @@ import type {
   NeonBuilderHandle,
 } from "./types.d.ts";
 import { IdentityAssertionSigner } from "./IdentityAssertion.js";
+
+// c2pa-rs `DataHash` uses `#[serde(with = "serde_bytes")]` for `hash` and
+// `pad`, which deserializes from a JSON array of u8 (not a `Buffer` object,
+// whose default JSON shape is `{ type: "Buffer", data: [...] }`). Normalize
+// any byte-like input to `number[]`. `pad` is a required field on the Rust
+// side, so default it to an empty array if the caller omits it.
+function bytesToNumberArray(
+  input: Buffer | Uint8Array | number[] | undefined,
+): number[] {
+  if (input === undefined) return [];
+  if (Array.isArray(input)) return input;
+  return Array.from(input);
+}
+
+function serializeDataHash(dataHash: DataHash): string {
+  return JSON.stringify({
+    name: dataHash.name,
+    alg: dataHash.alg,
+    hash: bytesToNumberArray(dataHash.hash),
+    pad: bytesToNumberArray(dataHash.pad),
+    exclusions: dataHash.exclusions,
+  });
+}
 
 export class Builder implements BuilderInterface {
   constructor(private builder: NeonBuilderHandle) {}
@@ -244,6 +268,32 @@ export class Builder implements BuilderInterface {
       .catch((error: Error) => {
         throw error;
       });
+  }
+
+  signDataHashedEmbeddable(
+    signer: LocalSignerInterface,
+    dataHash: DataHash,
+    format: string,
+  ): Buffer {
+    return getNeonBinary().builderSignDataHashedEmbeddable.call(
+      this.builder,
+      signer.getHandle(),
+      serializeDataHash(dataHash),
+      format,
+    );
+  }
+
+  async signDataHashedEmbeddableAsync(
+    signer: CallbackSignerInterface,
+    dataHash: DataHash,
+    format: string,
+  ): Promise<Buffer> {
+    return getNeonBinary().builderSignDataHashedEmbeddableAsync.call(
+      this.builder,
+      signer.getHandle(),
+      serializeDataHash(dataHash),
+      format,
+    );
   }
 
   getManifestDefinition(): Manifest {

--- a/js-src/index.node.d.ts
+++ b/js-src/index.node.d.ts
@@ -81,6 +81,16 @@ declare module "index.node" {
     input: SourceAsset,
     output: DestinationAsset,
   ): Promise<Buffer | { manifest: Buffer; signedAsset: Buffer }>;
+  export function builderSignDataHashedEmbeddable(
+    signer: NeonLocalSignerHandle,
+    dataHashJson: string,
+    format: string,
+  ): Buffer;
+  export function builderSignDataHashedEmbeddableAsync(
+    signer: NeonCallbackSignerHandle,
+    dataHashJson: string,
+    format: string,
+  ): Promise<Buffer>;
   export function builderManifestDefinition(): string;
   export function builderUpdateManifestProperty(
     property: string,

--- a/js-src/types.d.ts
+++ b/js-src/types.d.ts
@@ -107,6 +107,33 @@ export type SourceAsset = SourceBufferAsset | FileAsset;
 export type DestinationAsset = DestinationBufferAsset | FileAsset;
 
 /**
+ * A pre-computed data hash assertion. Pass to `signDataHashedEmbeddable` to
+ * produce a signed embeddable manifest without needing the asset bytes at
+ * sign time (e.g. for sidecar / remote-manifest workflows).
+ *
+ * For a spec-compliant raw SHA-256 of the whole asset, use:
+ * `{ alg: "sha256", hash: <raw sha256 bytes>, exclusions: [], pad: Buffer.alloc(0) }`
+ *
+ * The shape mirrors the c2pa-rs `DataHash` serde struct. `hash` and `pad`
+ * are serialized as byte arrays (serde_bytes).
+ */
+export interface DataHash {
+  /** Optional friendly name (e.g. `"raw asset"`). */
+  name?: string;
+  /** Hash algorithm. Use `"sha256"` for sidecar / spec-compliant flows. */
+  alg?: "sha256" | "sha384" | "sha512";
+  /** Hash bytes. */
+  hash: Buffer | Uint8Array | number[];
+  /** Padding bytes. May be empty. */
+  pad?: Buffer | Uint8Array | number[];
+  /**
+   * Byte ranges (in the target asset) excluded from the hash. Empty means
+   * the hash covers the entire asset.
+   */
+  exclusions?: { start: number; length: number }[];
+}
+
+/**
  * The return type of resourceToAsset.
  * When the asset is a file, returns the number of bytes written.
  * When the asset is a buffer, returns an object with the buffer and bytes written.
@@ -320,6 +347,45 @@ export interface BuilderInterface {
     filePath: string,
     output: DestinationAsset,
   ): Buffer;
+
+  /**
+   * Produce a signed embeddable manifest from a pre-computed DataHash.
+   *
+   * Unlike `sign`, this does **not** require the asset bytes at sign time —
+   * the caller has already computed the hash externally. The returned
+   * manifest binary can be embedded by the caller, or shipped as a sidecar
+   * / referenced via a remote-manifest URL.
+   *
+   * Typical use: sidecar / remote-manifest signing where only the SHA-256 digest of
+   * the asset is available. With `exclusions: []` and `alg: "sha256"`,
+   * `c2pa.hash.data.hash` in the resulting manifest equals `SHA-256(asset)`,
+   * which a verifier can recompute from the original file.
+   *
+   * @param signer The local signer
+   * @param dataHash The pre-computed data hash
+   * @param format MIME type of the target asset (e.g. `"image/jpeg"`)
+   * @returns The signed `c2pa_manifest` bytes (preformatted for `format`)
+   */
+  signDataHashedEmbeddable(
+    signer: LocalSignerInterface,
+    dataHash: DataHash,
+    format: string,
+  ): Buffer;
+
+  /**
+   * Async variant of `signDataHashedEmbeddable` that uses a CallbackSigner
+   * (e.g. for KMS-backed or otherwise asynchronous signing).
+   *
+   * @param signer The callback signer
+   * @param dataHash The pre-computed data hash
+   * @param format MIME type of the target asset
+   * @returns The signed `c2pa_manifest` bytes
+   */
+  signDataHashedEmbeddableAsync(
+    signer: CallbackSignerInterface,
+    dataHash: DataHash,
+    format: string,
+  ): Promise<Buffer>;
 
   /**
    * Getter for the builder's manifest definition

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@contentauth/c2pa-node",
+  "name": "@stabilityprotocol/c2pa-node",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentauth/c2pa-node-v2.git"
+    "url": "git+https://github.com/stabilityprotocol/c2pa-node-v2.git"
   },
   "version": "0.5.5",
   "description": "Node.js bindings for C2PA",
@@ -74,9 +74,9 @@
     "c2pa"
   ],
   "bugs": {
-    "url": "https://github.com/contentauth/c2pa-node-v2/issues"
+    "url": "https://github.com/stabilityprotocol/c2pa-node-v2/issues"
   },
-  "homepage": "https://github.com/contentauth/c2pa-node-v2#readme",
+  "homepage": "https://github.com/stabilityprotocol/c2pa-node-v2#readme",
   "dependencies": {
     "cargo-cp-artifact": "^0.1.9",
     "cli-progress": "^3.12.0",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,14 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         neon_builder::NeonBuilder::identity_sign_async,
     )?;
     cx.export_function(
+        "builderSignDataHashedEmbeddable",
+        neon_builder::NeonBuilder::sign_data_hashed_embeddable,
+    )?;
+    cx.export_function(
+        "builderSignDataHashedEmbeddableAsync",
+        neon_builder::NeonBuilder::sign_data_hashed_embeddable_async,
+    )?;
+    cx.export_function(
         "builderManifestDefinition",
         neon_builder::NeonBuilder::manifest_definition,
     )?;

--- a/src/neon_builder.rs
+++ b/src/neon_builder.rs
@@ -18,7 +18,10 @@ use crate::neon_reader::NeonReader;
 use crate::neon_signer::{CallbackSignerConfig, NeonCallbackSigner, NeonLocalSigner};
 use crate::runtime::runtime;
 use crate::utils::parse_settings;
-use c2pa::{assertions::Action, Builder, BuilderIntent, Ingredient};
+use c2pa::{
+    assertions::{Action, DataHash},
+    AsyncSigner, Builder, BuilderIntent, Ingredient, Signer,
+};
 use neon::context::Context as NeonContext;
 use neon::prelude::*;
 use neon_serde4;
@@ -597,6 +600,82 @@ impl NeonBuilder {
                     } else {
                         Ok(result_buffer.upcast::<JsValue>())
                     }
+                }
+                Err(err) => cx.throw_error(err.to_string()),
+            });
+        });
+        Ok(promise)
+    }
+
+    /// Sign a pre-computed `DataHash` with a `LocalSigner`. Produces a
+    /// signed embeddable manifest binary without requiring asset bytes at
+    /// sign-time.
+    ///
+    /// Internally calls `Builder::data_hashed_placeholder` first (required
+    /// by upstream c2pa-rs to reserve the DataHash assertion slot), then
+    /// `Builder::sign_data_hashed_embeddable`. The placeholder bytes are
+    /// discarded — this binding targets sidecar / remote-manifest flows
+    /// where the caller does not need to embed the placeholder.
+    pub fn sign_data_hashed_embeddable(mut cx: FunctionContext) -> JsResult<JsBuffer> {
+        let rt = runtime();
+        let this = cx.this::<JsBox<Self>>()?;
+        let signer = cx.argument::<JsBox<NeonLocalSigner>>(0)?;
+        let data_hash_json = cx.argument::<JsString>(1)?.value(&mut cx);
+        let format = cx.argument::<JsString>(2)?.value(&mut cx);
+
+        let data_hash: DataHash = serde_json::from_str(&data_hash_json)
+            .or_else(|err| cx.throw_error(format!("Invalid DataHash JSON: {err}")))?;
+
+        let mut builder = rt.block_on(async { this.builder.lock().await });
+        let signer = signer.signer();
+        let reserve_size = signer.reserve_size();
+
+        // Required preamble: reserves DataHash slot in the builder definition.
+        builder
+            .data_hashed_placeholder(reserve_size, &format)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let bytes = builder
+            .sign_data_hashed_embeddable(&**signer, &data_hash, &format)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let buffer = JsBuffer::from_slice(&mut cx, bytes.as_slice())?;
+        Ok(buffer)
+    }
+
+    /// Async variant of `sign_data_hashed_embeddable` for `CallbackSigner`
+    /// (e.g. KMS-backed signing).
+    pub fn sign_data_hashed_embeddable_async(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let rt = runtime();
+        let channel = cx.channel();
+
+        let this = cx.this::<JsBox<Self>>()?;
+        let signer = cx.argument::<JsBox<NeonCallbackSigner>>(0)?;
+        let signer_ref: &NeonCallbackSigner = signer.deref();
+        let signer = signer_ref.clone();
+        let data_hash_json = cx.argument::<JsString>(1)?.value(&mut cx);
+        let format = cx.argument::<JsString>(2)?.value(&mut cx);
+
+        let data_hash: DataHash = serde_json::from_str(&data_hash_json)
+            .or_else(|err| cx.throw_error(format!("Invalid DataHash JSON: {err}")))?;
+
+        let reserve_size = <NeonCallbackSigner as AsyncSigner>::reserve_size(&signer);
+
+        let builder = Arc::clone(&this.builder);
+        let (deferred, promise) = cx.promise();
+        rt.spawn(async move {
+            let result = async {
+                let mut b = builder.lock().await;
+                b.data_hashed_placeholder(reserve_size, &format)?;
+                b.sign_data_hashed_embeddable_async(&signer, &data_hash, &format)
+                    .await
+            }
+            .await;
+
+            deferred.settle_with(&channel, move |mut cx| match result {
+                Ok(bytes) => {
+                    let buffer = JsBuffer::from_slice(&mut cx, bytes.as_slice())?;
+                    Ok(buffer.upcast::<JsValue>())
                 }
                 Err(err) => cx.throw_error(err.to_string()),
             });


### PR DESCRIPTION
# Summary

Expose `Builder.sign_data_hashed_embeddable` (and its async/CallbackSigner variant) from the underlying `c2pa` crate to the Node.js API. This enables sign-time flows where the asset bytes are not available but a pre-computed hash is — i.e. sidecar `.c2pa` files and remote-manifest URLs — without forcing callers to round-trip the asset through the Builder.

With `alg: "sha256"` and `exclusions: []`, the resulting manifest's `c2pa.hash.data.hash` equals `SHA-256(asset)`, so a verifier holding the original file can recompute the digest and validate the manifest.

# Motivation
`c2pa-rs` already supports this signing mode, but the Node binding only exposed the asset-in / asset-out `sign` path. Use cases that need it:

- **Sidecar signing** — sign once, ship asset.jpg and asset.jpg.c2pa separately.
- **Remote manifest** — sign once, host the manifest at a URL referenced by a future embedded c2pa.remote_manifest.
- **Hash-only inputs** — pipelines where only the digest is available at sign time (e.g. asset stored elsewhere, only metadata + hash crosses a boundary).