### PR TITLE
test: Update c2pa dependency version to 0.88.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 async-trait = "0.1.77"
 ciborium = "0.2.2"
-c2pa = { version = "0.82.1", default-features = false, features = ["file_io", "pdf", "fetch_remote_manifests", "add_thumbnails", "rust_native_crypto", "default_http"] }
+c2pa = { version = "0.88.0", default-features = false, features = ["file_io", "pdf", "fetch_remote_manifests", "add_thumbnails", "rust_native_crypto", "default_http"] }
 futures = "0.3"
 image = "0.25.6"
 neon = { version = "1.0.0", default-features = false, features = [


### PR DESCRIPTION
Bump c2pa-rs version to latest.